### PR TITLE
copy gcno files into dedictated directories

### DIFF
--- a/bluechi.spec.in
+++ b/bluechi.spec.in
@@ -236,7 +236,7 @@ will be used during integration tests when creating code coverage report.
 %files coverage
 %license LICENSE
 %{_datadir}/bluechi-coverage/bin/*
-%{_datadir}/bluechi-coverage/*.gcno
+%{_datadir}/bluechi-coverage/*
 %dir %{_localstatedir}/tmp/bluechi-coverage/
 %endif
 

--- a/build-scripts/install-coverage.sh
+++ b/build-scripts/install-coverage.sh
@@ -4,6 +4,12 @@
 # This script should be executed only from meson as a part of install flow!
 #
 # Install all created `*.gcno` files so they could be packaged into bluechi-coverage RPM.
-COV_DIR="${MESON_INSTALL_DESTDIR_PREFIX}/share/bluechi-coverage"
-mkdir -p "${COV_DIR}"
-find "${MESON_BUILD_ROOT}" -name '*.gcno' -exec cp "{}" "${COV_DIR}" \;
+
+for f in $MESON_BUILD_ROOT/src/*; do
+    if [ -d "$f" ]; then
+        COV_DIR="${MESON_INSTALL_DESTDIR_PREFIX}/share/bluechi-coverage"
+        COV_DIR="${COV_DIR}/${f##*/}"
+        mkdir -p "${COV_DIR}"
+        find "${f}" -name '*.gcno' -exec cp "{}" "${COV_DIR}" \;
+    fi
+done

--- a/tests/scripts/gather-code-coverage.sh
+++ b/tests/scripts/gather-code-coverage.sh
@@ -10,11 +10,16 @@ INFO_FILE=${1:-coverage.info}
 BC_VRA="$(rpm -q --qf '%{VERSION}-%{RELEASE}.%{ARCH}' bluechi-agent 2>/dev/null)"
 SRC_DIR="/usr/src/debug/bluechi-${BC_VRA}/src"
 
-# Remove path prefix from GCDA files
-(cd ${GCDA_DIR} && for file in *.gcda ; do mv ${file} ${file##*#} ; done)
-
 # Copy .gcno files to code coverage temporary directory
 cp -r ${GCNO_DIR}/. ${GCDA_DIR}
+
+# move each .gcda file into the respective project directory containing the .gcno
+for file in ${GCDA_DIR}/*.gcda ; do
+    # project directory, e.g. libbluechi, is at position 3 (hence -f-3)
+    project_dir=$(echo $file | rev | cut -d'#' -f-3 | rev | cut -d'#' -f-1)
+    filename=$(echo $file | rev | cut -d'#' -f-1 | rev)
+    mv $file ${GCDA_DIR}/$project_dir/$filename
+done
 
 # Generate info file
 geninfo ${GCDA_DIR} -b ${SRC_DIR} -o ${INFO_FILE}


### PR DESCRIPTION
By copying the gcno files into the dedicated directories naming collisions are avoided which, in turn, results in missing coverage for those overwritten files.